### PR TITLE
新着商品をデータベースから取得して表示

### DIFF
--- a/app/Customize/Twig/Extension/TwigExtension.php
+++ b/app/Customize/Twig/Extension/TwigExtension.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Customize\Twig\Extension;
+
+use Doctrine\Common\Collections;
+use Doctrine\ORM\EntityManagerInterface;
+use Eccube\Common\EccubeConfig;
+use Eccube\Entity\Master\ProductStatus;
+use Eccube\Entity\Product;
+use Eccube\Entity\ProductClass;
+use Eccube\Repository\ProductRepository;
+
+class TwigExtension extends \Twig_Extension
+{
+    /**
+     * @var EntityManagerInterface
+     */
+    private $entityManager;
+    /**
+     * @var EccubeConfig
+     */
+    protected $eccubeConfig;
+    /**
+     * @var ProductRepository
+     */
+    private $productRepository;
+    /**
+     * TwigExtension constructor.
+     *
+     */
+    public function __construct(
+        EntityManagerInterface $entityManager,
+        EccubeConfig $eccubeConfig,
+        ProductRepository $productRepository
+    ) {
+        $this->entityManager = $entityManager;
+        $this->eccubeConfig = $eccubeConfig;
+        $this->productRepository = $productRepository;
+    }
+    /**
+     * Returns a list of functions to add to the existing list.
+     *
+     * @return array An array of functions
+     */
+    public function getFunctions()
+    {
+        return array(
+            new \Twig_SimpleFunction('CustomizeNewProduct', array($this, 'getCustomizeNewProduct')),
+        );
+    }
+    /**
+     * Name of this extension
+     *
+     * @return string
+     */
+    public function getName()
+    {
+        return 'CustomizeTwigExtension';
+    }
+    /**
+     *
+     * 新着商品を3件返す
+     *
+     * @return Products|null
+     */
+    public function getCustomizeNewProduct()
+    {
+        try {
+            //検索条件の新着順を定義
+            $searchData = array();
+            $qb = $this->entityManager->createQueryBuilder();
+            $query = $qb->select("plob")
+                ->from("Eccube\\Entity\\Master\\ProductListOrderBy", "plob")
+                ->where('plob.id = :id')
+                ->setParameter('id', $this->eccubeConfig['eccube_product_order_newer'])
+                ->getQuery();
+            $searchData['orderby'] = $query->getOneOrNullResult();
+            //商品情報を3件取得
+            $qb = $this->productRepository->getQueryBuilderBySearchData($searchData);
+            $query = $qb->setMaxResults(3)->getQuery();
+            $products = $query->getResult();
+            return $products;
+        } catch (\Exception $e) {
+            return null;
+        }
+        return null;
+    }
+}

--- a/app/template/default/Block/new_item.twig
+++ b/app/template/default/Block/new_item.twig
@@ -8,6 +8,8 @@ http://www.ec-cube.co.jp/
 For the full copyright and license information, please view the LICENSE
 file that was distributed with this source code.
 #}
+{% set Products = CustomizeNewProduct() %}
+{% if Products|length > 0 %}
 
 <div class="ec-role">
     <div class="ec-newItemRole">
@@ -17,30 +19,29 @@ file that was distributed with this source code.
                     <span class="ec-secHeading__en">{{ 'front.block.new_item.title__en'|trans }}</span>
                     <span class="ec-secHeading__line"></span>
                     <span class="ec-secHeading__ja">{{ 'front.block.new_item.title__ja'|trans }}</span>
-                    <a class="ec-inlineBtn--top" href="{{ url('product_list') }}">{{ 'front.block.new_item.more'|trans }}</a>
+                    <a class="ec-inlineBtn--top" href="{{ url('product_list') }}?orderby={{eccube_config.eccube_product_order_newer}}">{{ 'front.block.new_item.more'|trans }}</a>
                 </div>
             </div>
+            {% for Product in Products %}
             <div class="ec-newItemRole__listItem">
-                <a href="{{ url('product_detail', {'id': '1'}) }}">
-                    <img src="{{ asset('cube-1.png', 'save_image') }}">
-                    <p class="ec-newItemRole__listItemTitle">{{ 'front.block.new_item.item_1_name'|trans }}</p>
-                    <p class="ec-newItemRole__listItemPrice">{{ 'front.block.new_item.item_1_price'|trans }}</p>
+                <a href="{{ url('product_detail', {'id': Product.id}) }}">
+                    <img src="{{ asset(Product.main_list_image|no_image_product, 'save_image') }}">
+                    <p class="ec-newItemRole__listItemTitle">{{ Product.name }}</p>
+                    <p class="ec-newItemRole__listItemPrice">
+                    {% if Product.hasProductClass %}
+                        {% if Product.getPrice02Min == Product.getPrice02Max %}
+                            {{ Product.getPrice02IncTaxMin|price }}
+                        {% else %}
+                            {{ Product.getPrice02IncTaxMin|price }} ～ {{ Product.getPrice02IncTaxMax|price }}
+                        {% endif %}
+                    {% else %}
+                        {{ Product.getPrice02IncTaxMin|price }}
+                    {% endif %}
+                    </p>
                 </a>
             </div>
-            <div class="ec-newItemRole__listItem">
-                <a href="{{ url('product_detail', {'id': '2'}) }}">
-                    <img src="{{ asset('sand-1.png', 'save_image') }}">
-                    <p class="ec-newItemRole__listItemTitle">{{ 'front.block.new_item.item_2_name'|trans }}</p>
-                    <p class="ec-newItemRole__listItemPrice">{{ 'front.block.new_item.item_2_price'|trans }}</p>
-                </a>
-            </div>
-            <div class="ec-newItemRole__listItem">
-                <a href="{{ url('product_detail', {'id': '1'}) }}">
-                    <img src="{{ asset('assets/img/top/new_ec.jpg','user_data') }}">
-                    <p class="ec-newItemRole__listItemTitle">{{ 'front.block.new_item.item_3_name'|trans }}</p>
-                    <p class="ec-newItemRole__listItemPrice">{{ 'front.block.new_item.item_3_price'|trans }}</p>
-                </a>
-            </div>
+            {% endfor %}
         </div>
     </div>
 </div>
+{% endif %}

--- a/html/user_data/assets/css/customize.css
+++ b/html/user_data/assets/css/customize.css
@@ -6,6 +6,27 @@
   }
   /* フッターのタイトルフォント変更 */
 .ec-footerTitle {
-    font-family: 'Philosopher', sans-serif;
-    color: blue;
+     font-family: 'Philosopher', sans-serif;
+}
+
+.ec-headerRole {
+    animation: color-change 5s linear infinite;
+}
+
+@keyframes color-change {
+  0%,100%{
+    background-color:#ff1493;
+  }
+
+  25%{
+    background-color:#7fff00;
+  }
+  
+  50%{
+    background-color:#0091EA;
+  }
+  
+  75%{
+    background-color:#9400d3;
+  }
 }


### PR DESCRIPTION
## 対象のissue

#1 


## 概要

トップページに固定で表示していた新着商品について、テーブルから3件取得して表示するように修正しました。

## 画面イメージ
<image  キャプチャ.PNG…]()
